### PR TITLE
fix: Disable Percy after first failed snapshot POST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  test:
+  node_8_with_percy:
     docker:
       - image: circleci/node:8-browsers
     steps:
@@ -9,10 +9,22 @@ jobs:
           name: Install dependencies
           command: yarn
       - run:
-          name: Run tests
+          name: Run tests with Percy
           command: yarn test
+  node_10:
+    docker:
+      - image: circleci/node:10-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: Run tests (without Percy)
+          command: PERCY_ENABLE=0 yarn test
 workflows:
   version: 2.1
   test:
     jobs:
-      - test
+      - node_8_with_percy
+      - node_10

--- a/index.js
+++ b/index.js
@@ -8,7 +8,13 @@ const {
 const sdkPkg = require("./package.json");
 const testCafePkg = require("testcafe/package.json");
 
+let isPercyRunning = true;
+
 async function percySnapshot(test, snapshotName, snapshotOptions) {
+  if (!isPercyRunning) {
+    return;
+  }
+
   let getURL = ClientFunction(() => window.location.href).with({
     boundTestRun: test
   });
@@ -63,6 +69,7 @@ async function postDomSnapshot(name, domSnapshot, url, options) {
 
   if (!postSuccess) {
     console.log(`[percy] Error posting snapshot to agent`);
+    isPercyRunning = false;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ async function postDomSnapshot(name, domSnapshot, url, options) {
   });
 
   if (!postSuccess) {
-    console.log(`[percy] Error posting snapshot to agent`);
+    console.log(`[percy] Error posting snapshot to agent, disabling Percy`);
     isPercyRunning = false;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,9 +111,9 @@
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
 "@percy/agent@~0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.9.0.tgz#4c775aac4855f110042091b6213316bffadf159b"
-  integrity sha512-VjkqHLguwcY6WgKtxc2kviK/RzsBMMcMPp2EkuIhEjunQb5x5OJ3B7rm3bVMsdDOvToD/YHo0xaMVGOzIZ50Fg==
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.10.0.tgz#c9a08b18526da7358f0f0892d6ec319b28da1dba"
+  integrity sha512-Y5Nlt1G4lEcra6vkyKXN2mg7RlY7l984AaTDf/yxK2jgiqEkXjDO8xGa0/+k0OGVhhtw82LOJe+QiktIISrNMw==
   dependencies:
     "@oclif/command" "1.5.16"
     "@oclif/config" "^1"


### PR DESCRIPTION
## What is this? 

We don't want to fill the users test suite with error logs. If the first request fails we can safely disable Percy after. 