### PR TITLE
✨ Allow an explicit test controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ $ percy exec -- testcafe chrome:headless tests
 ## Configuration
 
 `percySnapshot(name[, options])`
+`percySnapshot(t, name[, options])`
 
+- `t` - The test controller can be provided when it cannot be implicitly resolved
 - `name` (**required**) - The snapshot name; must be unique to each snapshot
 - `options` - Additional snapshot options (overrides any project options)
   - `options.widths` - An array of widths to take screenshots at
@@ -81,16 +83,18 @@ $ percy exec -- testcafe chrome:headless tests
 ## Upgrading
 
 In previous versions of `@percy/testcafe`, the test controller (`t`) was a required argument for the
-`percySnapshot` function. This is no longer the case, as an [implicit test
+`percySnapshot` function. An [implicit test
 controller](https://devexpress.github.io/testcafe/documentation/reference/test-api/testcontroller/#implicit-test-controller-use)
-is now used.
+can now be used, however an explicit controller can still be provided when it cannot be implicitly
+resolved.
 
 ```javascript
 // before
 await percySnapshot(t, 'Snapshot Name', options);
 
-// after
+// after (both options are valid)
 await percySnapshot('Snapshot Name', options);
+await percySnapshot(t, 'Snapshot Name', options);
 ```
 
 ### Migrating Config

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const utils = require('@percy/sdk-utils');
-const { t } = require('testcafe');
+const { t: implicit } = require('testcafe');
 
 // Collect client and environment information
 const sdkPkg = require('./package.json');
@@ -8,7 +8,9 @@ const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${testCafePkg.name}/${testCafePkg.version}`;
 
 // Take a DOM snapshot and post it to the snapshot endpoint
-module.exports = async function percySnapshot(name, options) {
+module.exports = async function percySnapshot(t, name, options) {
+  // if name is the first arg, assume an implicit controller
+  if (!t || typeof t === 'string') [t, name, options] = [implicit, t, name];
   if (!name) throw new Error('The `name` argument is required.');
   if (!(await utils.isPercyEnabled())) return;
   let log = utils.logger('testcafe');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -54,6 +54,25 @@ test('posts snapshots to the local percy server', async () => {
   expect(sdk.logger.stderr).toEqual([]);
 });
 
+test('can work with an explicit test controller', async t => {
+  await percySnapshot(t, 'Snapshot 1');
+
+  expect(sdk.server.requests).toEqual([
+    ['/percy/healthcheck'],
+    ['/percy/dom.js'],
+    ['/percy/snapshot', {
+      name: 'Snapshot 1',
+      url: 'http://localhost:8000/',
+      domSnapshot: '<html><head></head><body>Snapshot Me</body></html>',
+      clientInfo: expect.stringMatching(/@percy\/testcafe\/.+/),
+      environmentInfo: expect.stringMatching(/testcafe\/.+/)
+    }]
+  ]);
+
+  expect(sdk.logger.stdout).toEqual([]);
+  expect(sdk.logger.stderr).toEqual([]);
+});
+
 test('handles snapshot errors', async () => {
   sdk.test.failure('/percy/snapshot', 'failure');
 


### PR DESCRIPTION
## What is this?

This allows the new implicit syntax to be optional, providing less friction when updating and also allowing a path forward when an implicit controller does not work for whatever reason.