### PR TITLE
💥Remove implicit controllers & use `ClientFunction` over eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fixture('MyFixture')
 
 test('Test1', async t => {
   await t.typeText('#developer-name', 'John Doe');
-  await percySnapshot('TestCafe Example');
+  await percySnapshot(t, 'TestCafe Example');
 });
 ```
 
@@ -68,10 +68,9 @@ $ percy exec -- testcafe chrome:headless tests
 
 ## Configuration
 
-`percySnapshot(name[, options])`
 `percySnapshot(t, name[, options])`
 
-- `t` - The test controller can be provided when it cannot be implicitly resolved
+- `t`(**required**) - The test controller instance passed from `test`
 - `name` (**required**) - The snapshot name; must be unique to each snapshot
 - `options` - Additional snapshot options (overrides any project options)
   - `options.widths` - An array of widths to take screenshots at
@@ -81,21 +80,6 @@ $ percy exec -- testcafe chrome:headless tests
   - `options.enableJavaScript` - Enable JavaScript in Percy's rendering environment
 
 ## Upgrading
-
-In previous versions of `@percy/testcafe`, the test controller (`t`) was a required argument for the
-`percySnapshot` function. An [implicit test
-controller](https://devexpress.github.io/testcafe/documentation/reference/test-api/testcontroller/#implicit-test-controller-use)
-can now be used, however an explicit controller can still be provided when it cannot be implicitly
-resolved.
-
-```javascript
-// before
-await percySnapshot(t, 'Snapshot Name', options);
-
-// after (both options are valid)
-await percySnapshot('Snapshot Name', options);
-await percySnapshot(t, 'Snapshot Name', options);
-```
 
 ### Migrating Config
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const ENV_INFO = `${testCafePkg.name}/${testCafePkg.version}`;
 
 // Take a DOM snapshot and post it to the snapshot endpoint
 module.exports = async function percySnapshot(t, name, options) {
-  if (!t) throw new Error('The `test` argument is required.');
+  if (!t) throw new Error("The test function's `t` argument is required.");
   if (!name) throw new Error('The `name` argument is required.');
   if (!(await utils.isPercyEnabled())) return;
   let log = utils.logger('testcafe');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const utils = require('@percy/sdk-utils');
-const { ClientFunction } = require('testcafe');
 
 // Collect client and environment information
 const sdkPkg = require('./package.json');
@@ -17,15 +16,15 @@ module.exports = async function percySnapshot(t, name, options) {
   try {
     // Inject the DOM serialization script
     /* eslint-disable-next-line no-new-func */
-    await ClientFunction(new Function(await utils.fetchPercyDOM()), { boundTestRun: t })();
+    await t.eval(new Function(await utils.fetchPercyDOM()), { boundTestRun: t });
 
     // Serialize and capture the DOM
     /* istanbul ignore next: no instrumenting injected code */
-    let { domSnapshot, url } = await ClientFunction(() => ({
+    let { domSnapshot, url } = await t.eval(() => ({
       /* eslint-disable-next-line no-undef */
       domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), { boundTestRun: t, dependencies: { options } })();
+    }), { boundTestRun: t, dependencies: { options } });
 
     // Post the DOM to the snapshot endpoint with snapshot options and other info
     await utils.postSnapshot({

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,7 @@ fixture('percySnapshot')
 
 test('throws an error when a test is not provided', async () => {
   await expect(percySnapshot())
-    .rejects.toThrow('The `test` argument is required.');
+    .rejects.toThrow("The test function's `t` argument is required.");
 });
 
 test('throws an error when a name is not provided', async t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,7 +297,7 @@
   dependencies:
     dotenv "^8.2.0"
 
-"@percy/logger@^1.0.0-beta.36", "@percy/logger@^1.0.0-beta.39":
+"@percy/logger@^1.0.0-beta.39":
   version "1.0.0-beta.39"
   resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.39.tgz#dd5c03866d0d494157be191237602d86d43de5ff"
   integrity sha512-aEnKxCO3r9+bhxogIhJhxjh80QGImiIhbmik/oKCWNIc2KywATGRXsJvRmlF1DskA+RQcwzG/fENerSLNRycgQ==


### PR DESCRIPTION
## What is this?

When integrating with the example app, it appears the implicit controller will never work. In order to call client functions / eval outside of `test`, you have to pass an instance of the controller. 

```
eval cannot implicitly resolve the test run in context of which it should be executed. 
If you need to call eval from the Node.js API callback, pass the test controller manually via eval’s .with({ boundTestRun: t }) method first. 
*Note that you cannot execute eval outside the test code*
```

Knowing that, we have to drop that feature. Thankfully it only ever lived on the beta channels (and didn't work anyways). Along those lines, we have to use `ClientFunction` because `eval` is only available inside of `test`. (ClientFunction is what eval uses anyways). 