### PR TITLE
🧹 Fix stale issue label & dependabot GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,17 @@ version: 2
 updates:
 - package-ecosystem: npm
   directory: /
+  labels:
+    - ⬆️⬇️ dependencies
   schedule:
     interval: weekly
   commit-message:
     prefix: ⬆️
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ⬆️👷
+  labels:
+    - ⬆️⬇️ dependencies

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,3 +28,4 @@ jobs:
           exempt-issue-labels: '🐛 bug,❄️ on ice,✨ enhancement'
           exempt-all-assignees: true
           stale-pr-label: '🍞 stale'
+          stale-issue-label: '🍞 stale'


### PR DESCRIPTION
## What is this?

Forgot to add `stale-issue-label` to the config 🤦🏻‍♂️ (all of the repos added a generic "Stale" label 🤢 )

Also adds dependabot for our actions deps too (to match the CLI config)