### PR TITLE
🐛 Update peer dependency on testcafe to include 2.x+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@percy/sdk-utils": "^1.1.1"
   },
   "peerDependencies": {
-    "testcafe": "~1"
+    "testcafe": ">=1"
   },
   "devDependencies": {
     "@percy/cli": "^1.9.1",


### PR DESCRIPTION
## What is this?

TestCafe released 2.x of their package so we should update the peerDep so it doesn't complain on install. 

Closes #268 