### PR TITLE
chore: release 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/testcafe",
   "description": "TestCafe client library for visual testing with Percy",
-  "version": "1.0.5-beta.1",
+  "version": "1.0.5",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-testcafe",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `1.0.5-beta.1` to stable `1.0.5`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v1.0.5` release exists (no git tag yet) — publish/replace it at release time.